### PR TITLE
Fixed validateScope by implementing correct method signature

### DIFF
--- a/components/oauth/models.js
+++ b/components/oauth/models.js
@@ -237,7 +237,7 @@ function getRefreshToken(refreshToken) {
     });
 }
 
-function validateScope(token, client) {
+function validateScope(user, client, scope) {
   return (user.scope === scope && client.scope === scope && scope !== null) ? scope : false
 }
 


### PR DESCRIPTION
Updated `models.js` so it uses the method signature specified in [oauthjs/node-oauth2-server](https://github.com/oauthjs/node-oauth2-server/blob/bbb4f133f4d475b719ea663280c2247662751ed9/lib/grant-types/abstract-grant-type.js).