### PR TITLE
Fixing model.validateScope

### DIFF
--- a/components/oauth/models.js
+++ b/components/oauth/models.js
@@ -237,8 +237,8 @@ function getRefreshToken(refreshToken) {
     });
 }
 
-function validateScope(token, client) {
-  return (user.scope === scope && client.scope === scope && scope !== null) ? scope : false
+function validateScope(token, client, scope) {
+  return (token.scope === scope && client.scope === scope && scope !== null) ? scope : false
 }
 
 function verifyScope(token, scope) {


### PR DESCRIPTION
- adding missing scope parameter
- renaming user to token in function body to match parameter name